### PR TITLE
fix: update deploy scripts to load env with env-cmd

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,9 +69,11 @@ jobs:
           fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
+      - name: Write DEPLOYER_PRIVATE_KEY to .env
+        run: echo "DEPLOYER_PRIVATE_KEY=${{ vars.DEPLOYER_PRIVATE_KEY }}" >> packages/contracts/.env
       - name: Run Tests
         shell: bash
         run: |
           pnpm supersim &
-          pnpm deploy:contracts:ci
+          pnpm contracts:deploy:dev
           pnpm e2e-test:ci

--- a/package.json
+++ b/package.json
@@ -4,18 +4,20 @@
   "description": "",
   "scripts": {
     "dev": "mprocs",
-    "install:contracts": "cd packages/contracts && forge install",
+    "install:contracts": "pnpm nx run @superchainerc20-starter/contracts:install",
     "contracts:update:rpcs": "pnpm nx run @superchainerc20-starter/contracts:update:rpcs",
     "contracts:deploy:token": "pnpm nx run @superchainerc20-starter/contracts:deploy:token",
     "update:toc": "doctoc README.md",
     "e2e-test": "mprocs -c mprocs-e2e-test.yaml",
     "init:env": "pnpm nx run-many --target=init:env",
-    "deploy:contracts:ci": "wait-port http://:8420/ready && cd packages/contracts && forge install && DEPLOY_CONFIG_PATH=/test/configs/test-deploy-config.toml forge script scripts/SuperchainERC20Deployer.s.sol --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    "contracts:deploy:dev": "pnpm install:contracts && pnpm nx run @superchainerc20-starter/contracts:deploy:dev",
     "e2e-test:ci": "pnpm nx run @superchainerc20-starter/e2e-test:test"
   },
   "license": "MIT",
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "doctoc": "^2.2.1",
+    "env-cmd": "^10.1.0",
     "mprocs": "^0.7.1",
     "nx": "^20.0.7",
     "prettier": "^3.3.3",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -2,8 +2,8 @@
   "name": "@superchainerc20-starter/contracts",
   "main": "index.js",
   "scripts": {
-    "deploy:dev": "source .env && wait-port  http://:8420/ready && forge script scripts/SuperchainERC20Deployer.s.sol --broadcast --private-key $DEPLOYER_PRIVATE_KEY",
-    "deploy:token": "source .env && forge script scripts/SuperchainERC20Deployer.s.sol --broadcast --private-key $DEPLOYER_PRIVATE_KEY",
+    "deploy:dev": "env-cmd -f .env cross-env-shell 'wait-port http://:8420/ready && forge script scripts/SuperchainERC20Deployer.s.sol --broadcast --private-key $DEPLOYER_PRIVATE_KEY'",
+    "deploy:token": "env-cmd -f .env cross-env-shell 'forge script scripts/SuperchainERC20Deployer.s.sol --broadcast --private-key $DEPLOYER_PRIVATE_KEY'",
     "update:rpcs": "cd ../.. && ./scripts/fetch-superchain-rpc-urls.sh",
     "install": "forge install",
     "build": "forge build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     devDependencies:
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       doctoc:
         specifier: ^2.2.1
         version: 2.2.1
+      env-cmd:
+        specifier: ^10.1.0
+        version: 10.1.0
       mprocs:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2909,6 +2915,11 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+
   cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
 
@@ -3122,6 +3133,11 @@ packages:
   entities@3.0.1:
     resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
     engines: {node: '>=0.12'}
+
+  env-cmd@10.1.0:
+    resolution: {integrity: sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -9106,6 +9122,10 @@ snapshots:
 
   crc-32@1.2.2: {}
 
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.3
+
   cross-fetch@3.1.8:
     dependencies:
       node-fetch: 2.7.0
@@ -9316,6 +9336,11 @@ snapshots:
   entities@2.2.0: {}
 
   entities@3.0.1: {}
+
+  env-cmd@10.1.0:
+    dependencies:
+      commander: 4.1.1
+      cross-spawn: 7.0.3
 
   error-ex@1.3.2:
     dependencies:


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/superchainerc20-starter/issues/57

Update env variables to be loaded with a combination of `env-cmd` and `cross-env-shell` in order to make sure that environment variable loading inside of pnpm scripts works across all environments.