### PR TITLE
fix error in AlertTitle Update alert.tsx

### DIFF
--- a/packages/frontend/src/components/ui/alert.tsx
+++ b/packages/frontend/src/components/ui/alert.tsx
@@ -33,7 +33,7 @@ const Alert = React.forwardRef<
 Alert.displayName = 'Alert'
 
 const AlertTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h5


### PR DESCRIPTION
**Description**

The `AlertTitle` uses `HTMLParagraphElement`, but it renders as `<h5>`. This can lead to a type mismatch.

Fixed