### PR TITLE
chore: Migrate github workflows to CircleCI [1/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,16 @@ parameters:
   run-main:
     type: boolean
     description: Triggers the main workflow to run
-    # We'll enable this workflow on main by default
-    # and let the user enable it when triggering the pipeline manually
-    default: << pipeline.git.branch.is_default >>
+    default: false
 
 workflows:
   main:
-    when: << pipeline.parameters.run-main >>
+    when: 
+      # We'll enable this workflow on main by default
+      # and let the user enable it when triggering the pipeline manually
+      or: 
+        - << pipeline.git.branch.is_default >>
+        - << pipeline.parameters.run-main >>
     jobs:
       - lint
       - test-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ jobs:
   test-e2e:
     executor: default
     environment:
-      DEPLOYER_PRIVATE_KEY: 0x0
+      # The first account created from "test test ... test junk" mnemonic
+      DEPLOYER_PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     steps:
       - checkout
       - install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,11 @@ parameters:
     type: boolean
     description: Triggers the main workflow to run
     default: false
+  test-e2e-deployer-private-key:
+    type: string
+    description: Deployer private key for the E2E tests
+    # The first account created from "test test ... test junk" mnemonic
+    default: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
 workflows:
   main:
@@ -50,8 +55,7 @@ jobs:
   test-e2e:
     executor: default
     environment:
-      # The first account created from "test test ... test junk" mnemonic
-      DEPLOYER_PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+      DEPLOYER_PRIVATE_KEY: << pipeline.parameters.test-e2e-deployer-private-key >>
     steps:
       - checkout
       - install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,6 @@ orbs:
   node: circleci/node@7.0.0
 
 parameters:
-  run-main:
-    type: boolean
-    description: Triggers the main workflow to run
-    default: false
   test-e2e-deployer-private-key:
     type: string
     description: Deployer private key for the E2E tests
@@ -21,12 +17,6 @@ parameters:
 
 workflows:
   main:
-    when: 
-      # We'll enable this workflow on main by default
-      # and let the user enable it when triggering the pipeline manually
-      or: 
-        - << pipeline.git.branch.is_default >>
-        - << pipeline.parameters.run-main >>
     jobs:
       - lint
       - test-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,17 @@ executors:
 orbs:
   node: circleci/node@7.0.0
 
+parameters:
+  run-main:
+    type: boolean
+    description: Triggers the main workflow to run
+    # We'll enable this workflow on main by default
+    # and let the user enable it when triggering the pipeline manually
+    default: << pipeline.git.branch.is_default >>
+
 workflows:
   main:
-    when: << pipeline.git.branch.is_default >>
+    when: << pipeline.parameters.run-main >>
     jobs:
       - lint
       - test-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+version: 2.1
+
+executors:
+  default:
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.53.0
+
+orbs:
+  node: circleci/node@7.0.0
+
+workflows:
+  main:
+    when: << pipeline.git.branch.is_default >>
+    jobs:
+      - lint
+      - test-e2e
+      - test-unit
+      - typecheck
+
+commands:
+  install-dependencies:
+    steps:
+      - node/install:
+          install-pnpm: true
+          node-version: '20'
+      - node/install-packages:
+          pkg-manager: pnpm
+
+jobs:
+  lint:
+    executor: default
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Run TypeChecker
+          command: pnpm -r lint
+  
+  test-e2e:
+    executor: default
+    environment:
+      DEPLOYER_PRIVATE_KEY: 0x0
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Prepare env
+          command: echo "DEPLOYER_PRIVATE_KEY=$DEPLOYER_PRIVATE_KEY" >> packages/contracts/.env
+      - run: 
+          name: Run Tests
+          command: |
+            pnpm supersim &
+            pnpm contracts:deploy:dev
+            pnpm e2e-test:ci
+
+  test-unit:
+    executor: default
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Run Tests
+          command: pnpm -r --filter '!e2e-test' test
+  
+  typecheck:
+    executor: default
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Run TypeChecker
+          command: pnpm -r typecheck


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Migrates the current github workflow into CircleCI. The pipeline can still be triggered manually via the CircleCI UI (the `run-main` checkbox needs to be checked). The `DEPLOYER_PRIVATE_KEY` variable required for the E2E tests has been set to the first account created from the `test test test ... junk` mnemonic.