### PR TITLE
Fix NatSpec @param name to match function parameter (_interfaceId)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ In this example our token supports `IERC7802`, `IERC20`, and `IERC165`
 
 ```solidity
 /// @notice Query if a contract implements an interface
-/// @param interfaceID The interface identifier, as specified in ERC-165
+/// @param _interfaceId The interface identifier, as specified in ERC-165
 /// @dev Interface identification is specified in ERC-165. This function
 /// uses less than 30,000 gas.
 /// @return `true` if the contract implements `interfaceID` and


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
In README.md file. Section: Updating an ERC-20 contract to be interoperable ->
This PR fixes a mismatch between the NatSpec @param tag and the actual function parameter name in the supportsInterface function.

Issue: The NatSpec referred to interfaceID, while the parameter is named _interfaceId, causing confusion and potential compile-time issues when copying the code.

Fix: Updated the @param tag to correctly reference _interfaceId for consistency and clarity.

**Tests**
N.A. It only a change in the README.md

**Additional context**
N.A.

**Metadata**
- Fixes #82 
